### PR TITLE
feat: v1.3.0 — zero-copy, modern deps, security headers, pedantic lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to nano-web will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0]
+
+### Changed
+
+- Zero-copy response buffers — `ResponseBuffer` now accepts `Bytes` directly, eliminating redundant `.to_vec()` copies on every compressed response
+- Replaced `fxhash` with `foldhash` — same perf, actively maintained by the same author
+- Replaced `chrono` with `httpdate` — `chrono` was overkill for HTTP date formatting, `httpdate` is purpose-built and tiny. **Note:** `/_health` timestamp format changed from RFC 3339 to HTTP-date
+- Removed redundant `FinalServeConfig` intermediate type in CLI
+- Replaced `#[inline(always)]` with `#[inline]` — let the compiler decide rather than forcing it
+- Strict clippy pedantic lints enabled via `[lints.clippy]` in `Cargo.toml`
+- `is_compressible()` simplified from match-with-identical-arms to `matches!` macro
+- `handle_request` no longer needlessly `async` — sync function returning `Result` is sufficient for hyper's `service_fn`
+
+### Added
+
+- Security headers: `Strict-Transport-Security`, `Permissions-Policy`, `X-DNS-Prefetch-Control`
+- `Vary: Accept-Encoding` header on compressed responses (correct HTTP caching semantics)
+- `Content-Length` header on all responses
+- MSRV 1.75 declared in `Cargo.toml`
+- Integration tests for new security headers, cache-control values, content-length, vary header
+- Dynamic port allocation in tests (no more hardcoded port conflicts)
+
+### Fixed
+
+- Pedantic clippy warnings: uninlined format args, `map`/`unwrap_or_else` patterns, match-for-single-pattern, doc backticks
+
 ## [1.2.0]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,12 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,12 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,19 +156,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
 
 [[package]]
 name = "clap"
@@ -381,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,15 +413,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -636,30 +599,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -943,18 +882,18 @@ dependencies = [
 
 [[package]]
 name = "nano-web"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "brotli",
  "bytes",
- "chrono",
  "clap",
  "clap_complete",
  "dashmap",
  "flate2",
- "fxhash",
+ "foldhash",
  "http-body-util",
+ "httpdate",
  "hyper",
  "hyper-util",
  "mimalloc",
@@ -999,15 +938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1916,41 +1846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "nano-web"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
+rust-version = "1.75"
 description = "Static file server built with Rust with pre-compressed in-memory caching"
 authors = ["James Cleveland <jc@blit.cc>"]
 license = "MIT"
@@ -21,12 +22,12 @@ path = "src/main.rs"
 anyhow = "1.0"
 brotli = "8.0"
 bytes = "1.10"
-chrono = "0.4"
+httpdate = "1"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 dashmap = "6.1"
 flate2 = "1.1"
-fxhash = "0.2"
+foldhash = "0.1"
 http-body-util = "0.1"
 hyper = { version = "1.6", features = ["http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "tokio"] }
@@ -54,6 +55,16 @@ zstd = "0.13"
 reqwest = { version = "0.12", features = ["json"] }
 tempfile = "3.8"
 tokio-test = "0.4"
+
+[lints.rust]
+unsafe_code = "warn"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 mimalloc = "0.1.43"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Static file server. Pre-loads and pre-compresses all files at startup for near-z
 - Raw hyper (no framework overhead)
 - SO_REUSEPORT for multi-core scaling
 - Files pre-compressed at startup (brotli/gzip/zstd)
-- Lock-free concurrent routing (DashMap + FxHash)
+- Lock-free concurrent routing (DashMap + foldhash)
 - Zero-copy responses (Bytes)
 
 Benchmark (M3 Max):
@@ -77,6 +77,10 @@ Variables: `{{env.VAR_NAME}}`, `{{Json}}`, `{{EscapedJson}}`
 ## Caching
 
 ETag and `If-None-Match` supported - returns 304 Not Modified when content hasn't changed.
+
+## Security Headers
+
+All responses include: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`, `Permissions-Policy`, `X-DNS-Prefetch-Control`. Compressed responses include `Vary: Accept-Encoding`.
 
 ## Health Check
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,16 +122,15 @@ impl Cli {
                 // Initialize logging with final values
                 init_logging(&final_log_level, &final_log_format);
 
-                let final_config = FinalServeConfig {
+                crate::server::start_server(crate::server::ServeConfig {
                     public_dir: serve_dir,
                     port: port.unwrap_or(self.port),
                     dev: dev || self.dev,
                     spa_mode: spa || self.spa,
                     config_prefix: config_prefix.unwrap_or(self.config_prefix),
                     log_requests: log_requests || self.log_requests,
-                };
-
-                final_config.serve().await
+                })
+                .await
             }
             Some(Commands::Version) => {
                 println!("{}", full_version());
@@ -150,29 +149,6 @@ impl Cli {
                 Ok(())
             }
         }
-    }
-}
-
-struct FinalServeConfig {
-    public_dir: PathBuf,
-    port: u16,
-    dev: bool,
-    spa_mode: bool,
-    config_prefix: String,
-    log_requests: bool,
-}
-
-impl FinalServeConfig {
-    async fn serve(self) -> Result<()> {
-        let config = crate::server::ServeConfig {
-            public_dir: self.public_dir,
-            port: self.port,
-            dev: self.dev,
-            spa_mode: self.spa_mode,
-            config_prefix: self.config_prefix,
-            log_requests: self.log_requests,
-        };
-        crate::server::start_server(config).await
     }
 }
 

--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -25,82 +25,30 @@ impl MimeConfig {
 pub fn get_mime_config<P: AsRef<Path>>(path: P) -> MimeConfig {
     let mime = MimeGuess::from_path(path)
         .first()
-        .map(|m| m.to_string())
-        .unwrap_or_else(|| DEFAULT_MIME.to_string());
+        .map_or_else(|| DEFAULT_MIME.to_string(), |m| m.to_string());
 
     MimeConfig::new(mime)
 }
 
 pub fn is_compressible(mime_type: &str) -> bool {
-    match mime_type {
-        // Text-based formats
+    matches!(
+        mime_type,
         "text/html"
-        | "text/css"
-        | "text/javascript"
-        | "text/plain"
-        | "text/csv"
-        | "text/markdown"
-        | "text/cache-manifest"
-        | "application/json"
-        | "application/ld+json"
-        | "application/manifest+json"
-        | "text/xml"
-        | "application/xml"
-        | "application/rss+xml"
-        | "application/atom+xml"
-        | "image/svg+xml" => true,
-
-        // Already compressed or binary
-        "image/jpeg"
-        | "image/png"
-        | "image/gif"
-        | "image/webp"
-        | "image/avif"
-        | "image/heic"
-        | "image/heif"
-        | "image/bmp"
-        | "image/tiff"
-        | "image/x-icon"
-        | "audio/mpeg"
-        | "audio/mp4"
-        | "audio/aac"
-        | "audio/ogg"
-        | "audio/flac"
-        | "audio/opus"
-        | "audio/wav"
-        | "video/mp4"
-        | "video/webm"
-        | "video/x-msvideo"
-        | "video/quicktime"
-        | "video/x-ms-wmv"
-        | "video/x-flv"
-        | "video/x-matroska"
-        | "font/woff"
-        | "font/woff2"
-        | "font/ttf"
-        | "font/otf"
-        | "application/vnd.ms-fontobject"
-        | "application/zip"
-        | "application/gzip"
-        | "application/x-bzip2"
-        | "application/vnd.rar"
-        | "application/x-7z-compressed"
-        | "application/x-xz"
-        | "application/x-tar"
-        | "application/pdf"
-        | "application/msword"
-        | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        | "application/vnd.ms-excel"
-        | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        | "application/vnd.ms-powerpoint"
-        | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        | "application/vnd.oasis.opendocument.text"
-        | "application/vnd.oasis.opendocument.spreadsheet"
-        | "application/vnd.oasis.opendocument.presentation"
-        | "application/octet-stream" => false,
-
-        _ => false,
-    }
+            | "text/css"
+            | "text/javascript"
+            | "text/plain"
+            | "text/csv"
+            | "text/markdown"
+            | "text/cache-manifest"
+            | "application/json"
+            | "application/ld+json"
+            | "application/manifest+json"
+            | "text/xml"
+            | "application/xml"
+            | "application/rss+xml"
+            | "application/atom+xml"
+            | "image/svg+xml"
+    )
 }
 
 pub fn is_templatable(mime_type: &str) -> bool {

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -14,7 +14,7 @@ impl Encoding {
 
     /// Parse Accept-Encoding header, priority: br > zstd > gzip > identity.
     /// Splits on comma to avoid substring false positives (e.g. "br" matching "vibrant").
-    #[inline(always)]
+    #[inline]
     pub fn from_accept_encoding(accept: &str) -> Self {
         let mut best = Self::Identity;
         for part in accept.split(',') {
@@ -42,7 +42,7 @@ pub struct ResponseBuffer {
 
 impl ResponseBuffer {
     pub fn new(
-        body: Vec<u8>,
+        body: Bytes,
         content_type: Arc<str>,
         content_encoding: Option<&'static str>,
         etag: Arc<str>,
@@ -50,7 +50,7 @@ impl ResponseBuffer {
         cache_control: Arc<str>,
     ) -> Self {
         Self {
-            body: Bytes::from(body),
+            body,
             content_type,
             content_encoding,
             etag,

--- a/src/template.rs
+++ b/src/template.rs
@@ -27,10 +27,11 @@ pub fn render_template(content: &str, config_prefix: &str) -> Result<String> {
             Json => json_string,
             EscapedJson => escaped_json
         })
-        .map_err(|e| anyhow::anyhow!("Template rendering error: {}", e))
+        .map_err(|e| anyhow::anyhow!("Template rendering error: {e}"))
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::*;
     use std::env;
@@ -70,11 +71,11 @@ mod tests {
 
     #[test]
     fn test_template_with_no_env_vars() {
-        let template = r#"
+        let template = r"
         <script>
             window.ENV = {{Json}};
         </script>
-        "#;
+        ";
 
         let result = render_template(template, "NONEXISTENT_").unwrap();
         assert!(result.contains("{}"));


### PR DESCRIPTION
## Summary

- **Zero-copy response buffers** — `ResponseBuffer` accepts `Bytes` directly, eliminating `.to_vec()` copies on every compressed response (`Bytes::clone` is an Arc refcount bump, not a memcpy)
- **Replace `fxhash` with `foldhash`** — actively maintained by the same author, HashDoS-resistant random seeding (security improvement for URL-keyed maps)
- **Replace `chrono` with `httpdate`** — purpose-built for HTTP date formatting, fraction of the dep weight. Note: `/_health` timestamp format changed from RFC 3339 to HTTP-date
- **Security headers** — `Strict-Transport-Security`, `Permissions-Policy`, `X-DNS-Prefetch-Control`, `Vary: Accept-Encoding` on compressed responses, `Content-Length` on all responses with correct HEAD semantics (RFC 9110 §9.3.2)
- **Clippy pedantic lints** enabled via `[lints.clippy]` — enforced across all targets including tests
- **Code cleanup** — removed `FinalServeConfig` indirection, merged split `impl` blocks, `#[inline(always)]` → `#[inline]`, `matches!` macro, sync `handle_request`
- **Test improvements** — dynamic port allocation (no more hardcoded port conflicts), 4 new tests for security headers / vary / content-length / cache-control values (16 total)

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test` — 16/16 pass
- [x] Pre-push hook (lefthook clippy) passes clean
- [x] Senior code review: correctness, security, performance, HTTP compliance all verified
- [x] HEAD `Content-Length` reflects real body size per RFC 9110 §9.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)