### PR TITLE
fix(security,correctness): audit fixes — sanitized paths, etags, q=0, vary, graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to nano-web will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0]
+
+### Fixed
+
+- **Security**: use sanitized path from `validate_request_path` for all route lookups instead of raw request URI — prevents potential path-based bypasses
+- **Correctness**: ETag now uses content hash (FxHash) instead of timestamp+length — deterministic across restarts, correct for identical content
+- **Correctness**: `Encoding::from_accept_encoding` now respects `q=0` (encoding explicitly rejected by client)
+- **Perf**: added `application/javascript` to compressible types — `mime_guess` returns this for `.js` files, so JS was silently not being compressed
+- **Correctness**: `Vary: Accept-Encoding` now sent on all compressible content types, not just compressed responses — fixes CDN/proxy cache poisoning
+
+### Added
+
+- Graceful shutdown via `tokio::signal` — handles SIGTERM and SIGINT for clean container stops
+
+### Changed
+
+- Replaced `.unwrap()` on response builders with `.expect()` for better panic diagnostics
+- Removed unused `CachedRoute.content` field — compressed data was duplicated between route cache and response cache
+- Removed unused HTTP/2 feature flags from `hyper` and `hyper-util` dependencies
+- Removed cargo-cult `#[inline(always)]` attributes — let the compiler decide
+
 ## [1.3.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1500,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ flate2 = "1.1"
 fxhash = "0.2"
 http-body-util = "0.1"
 httpdate = "1"
-hyper = { version = "1.6", features = ["http1", "http2", "server"] }
-hyper-util = { version = "0.1", features = ["http1", "http2", "server", "tokio"] }
+hyper = { version = "1.6", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["http1", "server", "tokio"] }
 mime_guess = "2.0"
 minijinja = "2.7"
 rayon = "1.10"
@@ -43,6 +43,7 @@ tokio = { version = "1.47", features = [
   "macros",
   "net",
   "rt-multi-thread",
+  "signal",
   "time",
 ] }
 tracing = "0.1"
@@ -60,7 +61,6 @@ tokio-test = "0.4"
 mimalloc = "0.1.43"
 
 [lints.clippy]
-inline_always = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"

--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -36,6 +36,7 @@ pub fn is_compressible(mime_type: &str) -> bool {
         "text/html"
             | "text/css"
             | "text/javascript"
+            | "application/javascript"
             | "text/plain"
             | "text/csv"
             | "text/markdown"
@@ -58,7 +59,7 @@ pub fn is_templatable(mime_type: &str) -> bool {
 pub fn is_asset(mime_type: &str) -> bool {
     match mime_type {
         // CSS and JavaScript
-        "text/css" | "text/javascript" => true,
+        "text/css" | "text/javascript" | "application/javascript" => true,
 
         // Images
         m if m.starts_with("image/") => true,

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -14,11 +14,24 @@ impl Encoding {
 
     /// Parse Accept-Encoding header, priority: br > zstd > gzip > identity.
     /// Splits on comma to avoid substring false positives (e.g. "br" matching "vibrant").
-    #[inline(always)]
+    /// Respects q=0 (encoding explicitly rejected by client).
     pub fn from_accept_encoding(accept: &str) -> Self {
         let mut best = Self::Identity;
         for part in accept.split(',') {
-            let token = part.split(';').next().unwrap_or("").trim();
+            let mut segments = part.split(';');
+            let token = segments.next().unwrap_or("").trim();
+
+            // q=0 means the encoding is explicitly rejected
+            let rejected = segments.any(|s| {
+                s.trim()
+                    .strip_prefix("q=")
+                    .and_then(|v| v.trim().parse::<f32>().ok())
+                    .is_some_and(|q| q == 0.0)
+            });
+            if rejected {
+                continue;
+            }
+
             match token {
                 "br" => return Self::Brotli, // highest priority, short-circuit
                 "zstd" => best = Self::Zstd,
@@ -39,6 +52,8 @@ pub struct ResponseBuffer {
     pub last_modified: Arc<str>,
     pub cache_control: Arc<str>,
     pub content_length: Arc<str>,
+    /// Whether Vary: Accept-Encoding should be sent (true for all compressible types)
+    pub vary_encoding: bool,
 }
 
 impl ResponseBuffer {
@@ -49,6 +64,7 @@ impl ResponseBuffer {
         etag: Arc<str>,
         last_modified: Arc<str>,
         cache_control: Arc<str>,
+        vary_encoding: bool,
     ) -> Self {
         let content_length: Arc<str> = Arc::from(body.len().to_string().as_str());
         Self {
@@ -59,6 +75,7 @@ impl ResponseBuffer {
             last_modified,
             cache_control,
             content_length,
+            vary_encoding,
         }
     }
 }
@@ -102,6 +119,27 @@ mod tests {
         assert_eq!(
             Encoding::from_accept_encoding("gzip;q=0.5, zstd;q=1.0"),
             Encoding::Zstd
+        );
+    }
+
+    #[test]
+    fn test_encoding_respects_q_zero() {
+        // q=0 means explicitly rejected
+        assert_eq!(
+            Encoding::from_accept_encoding("br;q=0, gzip"),
+            Encoding::Gzip
+        );
+        assert_eq!(
+            Encoding::from_accept_encoding("br;q=0, zstd;q=0, gzip"),
+            Encoding::Gzip
+        );
+        assert_eq!(
+            Encoding::from_accept_encoding("br;q=0, zstd;q=0, gzip;q=0"),
+            Encoding::Identity
+        );
+        assert_eq!(
+            Encoding::from_accept_encoding("gzip;q=0"),
+            Encoding::Identity
         );
     }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 use rayon::prelude::*;
+use std::hash::Hasher;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -16,7 +17,6 @@ type RouteMap = DashMap<Arc<str>, ResponseBuffer, FxBuildHasher>;
 
 #[derive(Debug, Clone)]
 struct CachedRoute {
-    content: Arc<CompressedContent>,
     path: Arc<PathBuf>,
     modified: SystemTime,
 }
@@ -41,7 +41,6 @@ impl ResponseCache {
         }
     }
 
-    #[inline(always)]
     fn get_map(&self, encoding: Encoding) -> &RouteMap {
         match encoding {
             Encoding::Identity => &self.identity,
@@ -51,7 +50,6 @@ impl ResponseCache {
         }
     }
 
-    #[inline(always)]
     fn get(&self, path: &str, encoding: Encoding) -> Option<ResponseBuffer> {
         // Try requested encoding first, fallback to identity for non-compressible files
         self.get_map(encoding)
@@ -88,7 +86,6 @@ impl NanoWeb {
         self.routes.len()
     }
 
-    #[inline(always)]
     pub fn get_response(&self, path: &str, accept_encoding: &str) -> Option<ResponseBuffer> {
         let encoding = Encoding::from_accept_encoding(accept_encoding);
         self.responses.get(path, encoding)
@@ -176,16 +173,16 @@ impl NanoWeb {
         };
 
         let compressed = CompressedContent::new(processed_content, mime_config.is_compressible)?;
-        let etag = Self::generate_etag(&modified, &compressed.plain);
+        let etag = Self::generate_etag(&compressed.plain);
         let last_modified = Self::format_http_date(modified);
 
         let ct: Arc<str> = Arc::from(mime_config.mime_type.as_str());
         let etag: Arc<str> = Arc::from(etag.as_str());
         let lm: Arc<str> = Arc::from(last_modified.as_str());
         let cc: Arc<str> = Arc::from(get_cache_control(&mime_config.mime_type));
+        let vary = mime_config.is_compressible;
 
         let route = CachedRoute {
-            content: Arc::new(compressed),
             path: Arc::new(file_path.to_path_buf()),
             modified,
         };
@@ -196,16 +193,17 @@ impl NanoWeb {
             url_path.clone(),
             Encoding::Identity,
             ResponseBuffer::new(
-                route.content.plain.clone(),
+                compressed.plain.clone(),
                 ct.clone(),
                 None,
                 etag.clone(),
                 lm.clone(),
                 cc.clone(),
+                vary,
             ),
         );
 
-        if let Some(data) = &route.content.gzip {
+        if let Some(data) = &compressed.gzip {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Gzip,
@@ -216,11 +214,12 @@ impl NanoWeb {
                     etag.clone(),
                     lm.clone(),
                     cc.clone(),
+                    vary,
                 ),
             );
         }
 
-        if let Some(data) = &route.content.brotli {
+        if let Some(data) = &compressed.brotli {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Brotli,
@@ -231,11 +230,12 @@ impl NanoWeb {
                     etag.clone(),
                     lm.clone(),
                     cc.clone(),
+                    vary,
                 ),
             );
         }
 
-        if let Some(data) = &route.content.zstd {
+        if let Some(data) = &compressed.zstd {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Zstd,
@@ -246,6 +246,7 @@ impl NanoWeb {
                     etag.clone(),
                     lm.clone(),
                     cc.clone(),
+                    vary,
                 ),
             );
         }
@@ -259,13 +260,10 @@ impl NanoWeb {
         Ok(Arc::from(url_path.as_str()))
     }
 
-    fn generate_etag(modified: &SystemTime, content: &[u8]) -> String {
-        use std::time::UNIX_EPOCH;
-        let timestamp = modified
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        format!("\"{:x}-{:x}\"", timestamp, content.len())
+    fn generate_etag(content: &[u8]) -> String {
+        let mut hasher = fxhash::FxHasher::default();
+        hasher.write(content);
+        format!("\"{:x}\"", hasher.finish())
     }
 
     fn format_http_date(time: SystemTime) -> String {

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::routes::NanoWeb;
 
@@ -60,26 +60,63 @@ pub async fn start_server(config: ServeConfig) -> Result<()> {
     info!("Starting server on http://{}", addr);
     info!("Serving directory: {:?}", config.public_dir);
 
+    let shutdown = shutdown_signal();
+    tokio::pin!(shutdown);
+
     loop {
-        let (stream, _) = listener.accept().await?;
-        let io = TokioIo::new(stream);
-        let state = state.clone();
-
-        tokio::spawn(async move {
-            let service = service_fn(move |req| {
+        tokio::select! {
+            result = listener.accept() => {
+                let (stream, _) = result?;
+                let io = TokioIo::new(stream);
                 let state = state.clone();
-                async move { handle_request(req, state) }
-            });
 
-            if let Err(e) = http1::Builder::new()
-                .keep_alive(true)
-                .pipeline_flush(true)
-                .serve_connection(io, service)
-                .await
-            {
-                debug!("Connection error: {}", e);
+                tokio::spawn(async move {
+                    let service = service_fn(move |req| {
+                        let state = state.clone();
+                        async move { handle_request(req, state) }
+                    });
+
+                    if let Err(e) = http1::Builder::new()
+                        .keep_alive(true)
+                        .pipeline_flush(true)
+                        .serve_connection(io, service)
+                        .await
+                    {
+                        debug!("Connection error: {}", e);
+                    }
+                });
             }
-        });
+            () = &mut shutdown => {
+                info!("Shutdown signal received, stopping server");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }
 
@@ -99,10 +136,10 @@ fn handle_request(
         ));
     }
 
-    let path = req.uri().path();
+    let raw_path = req.uri().path();
 
     // Health check
-    if path == "/_health" {
+    if raw_path == "/_health" {
         let body = format!(
             r#"{{"status":"ok","timestamp":"{}"}}"#,
             httpdate::fmt_http_date(std::time::SystemTime::now())
@@ -111,19 +148,22 @@ fn handle_request(
             .status(StatusCode::OK)
             .header("content-type", "application/json")
             .body(Full::new(Bytes::from(body)))
-            .unwrap());
+            .expect("health check response"));
     }
 
-    // Path validation
-    if let Err(e) = crate::path::validate_request_path(path) {
-        tracing::warn!("Path validation failed for '{}': {}", path, e);
-        return Ok(response(StatusCode::BAD_REQUEST, "Bad Request"));
-    }
+    // Path validation — use the sanitized path for all lookups
+    let path = match crate::path::validate_request_path(raw_path) {
+        Ok(sanitized) => sanitized,
+        Err(e) => {
+            warn!("Path validation failed for '{}': {}", raw_path, e);
+            return Ok(response(StatusCode::BAD_REQUEST, "Bad Request"));
+        }
+    };
 
     // Dev mode: refresh if modified
     if state.config.dev {
         let _ = state.server.refresh_if_modified(
-            path,
+            &path,
             &state.config.public_dir,
             &state.config.config_prefix,
         );
@@ -140,7 +180,7 @@ fn handle_request(
         .get("if-none-match")
         .and_then(|h| h.to_str().ok());
 
-    let mut buf = state.server.get_response(path, accept_encoding);
+    let mut buf = state.server.get_response(&path, accept_encoding);
 
     // Try with trailing slash
     if buf.is_none() && !path.ends_with('/') {
@@ -163,7 +203,7 @@ fn handle_request(
                     .header("etag", b.etag.as_ref())
                     .header("cache-control", b.cache_control.as_ref())
                     .body(Full::new(Bytes::new()))
-                    .unwrap());
+                    .expect("304 response"));
             }
         }
         build_response(b, is_head)
@@ -175,7 +215,7 @@ fn handle_request(
     if state.config.log_requests {
         info!(
             method = %req.method(),
-            path = path,
+            path = %path,
             status = resp.status().as_u16(),
             "request"
         );
@@ -184,15 +224,13 @@ fn handle_request(
     Ok(resp)
 }
 
-#[inline(always)]
 fn response(status: StatusCode, body: &'static str) -> HyperResponse {
     Response::builder()
         .status(status)
         .body(Full::new(Bytes::from_static(body.as_bytes())))
-        .unwrap()
+        .expect("error response")
 }
 
-#[inline(always)]
 fn build_response(buf: &crate::response_buffer::ResponseBuffer, head_only: bool) -> HyperResponse {
     let mut builder = Response::builder()
         .status(StatusCode::OK)
@@ -228,9 +266,12 @@ fn build_response(buf: &crate::response_buffer::ResponseBuffer, head_only: bool)
         );
 
     if let Some(encoding) = buf.content_encoding {
-        builder = builder
-            .header(header::CONTENT_ENCODING, HeaderValue::from_static(encoding))
-            .header(header::VARY, HeaderValue::from_static("Accept-Encoding"));
+        builder = builder.header(header::CONTENT_ENCODING, HeaderValue::from_static(encoding));
+    }
+
+    // Vary: Accept-Encoding for all compressible content, not just compressed responses
+    if buf.vary_encoding {
+        builder = builder.header(header::VARY, HeaderValue::from_static("Accept-Encoding"));
     }
 
     let body = if head_only {
@@ -239,5 +280,5 @@ fn build_response(buf: &crate::response_buffer::ResponseBuffer, head_only: bool)
         buf.body.clone()
     };
 
-    builder.body(Full::new(body)).unwrap()
+    builder.body(Full::new(body)).expect("response body")
 }


### PR DESCRIPTION
## Summary

- **Security**: Use sanitized path from `validate_request_path` for all route lookups instead of raw URI
- **ETag**: Content hash (FxHash) instead of timestamp+length — deterministic, correct for identical content
- **Compression**: Add `application/javascript` to compressible types (JS wasn't being compressed), fix `q=0` rejection in Accept-Encoding
- **Vary**: `Vary: Accept-Encoding` on all compressible content types, not just compressed responses
- **Shutdown**: Graceful shutdown via `tokio::signal` (SIGTERM + SIGINT)
- **Cleanup**: Replace `.unwrap()` with `.expect()`, remove dead `CachedRoute.content` field, drop unused HTTP/2 features, remove `#[inline(always)]` attributes

## Test plan

- [x] All 26 unit + integration tests pass
- [x] New test for `q=0` encoding rejection
- [x] Zero clippy warnings
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)