### PR TITLE
fix(ci): pass toolchain: stable to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -39,6 +41,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -53,6 +57,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -141,6 +147,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache dependencies
@@ -368,6 +375,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
## Summary

The new `dtolnay/rust-toolchain` SHA (bumped in #15) requires an explicit `toolchain` input — the prior SHA defaulted to stable when none was passed. Every job in #15's release run failed at "Install Rust" with \`'toolchain' is a required input\`.

All 5 invocations now pass \`toolchain: stable\` via \`with:\`.

## Test plan

- [x] All 5 uses of \`dtolnay/rust-toolchain\` updated (grep verified)
- [ ] CI passes on merge
- [ ] v1.4.1 release pipeline completes — check-version still sees 1.4.1 vs 1.4.0 last GH release

Fixes #15 aftermath.