### PR TITLE
experiment(do-not-merge): io_uring engine — negative result, does not beat hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "dashmap",
  "flate2",
  "http-body-util",
+ "httparse",
  "httpdate",
  "hyper",
  "hyper-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-const-array"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd73835ad7deb4bd2b389e6f10333b143f025d607c55ca04c66a0bcc6bb2fc6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +138,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -154,6 +177,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -476,6 +505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +698,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -787,6 +825,16 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -966,6 +1014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1069,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1019,6 +1088,37 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monoio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd0f8bcde87b1949f95338b547543fcab187bc7e7a5024247e359a5e828ba6a"
+dependencies = [
+ "auto-const-array",
+ "bytes",
+ "fxhash",
+ "io-uring",
+ "libc",
+ "memchr",
+ "mio 0.8.11",
+ "monoio-macros",
+ "nix",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "monoio-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1040,12 +1140,13 @@ dependencies = [
  "mimalloc",
  "mime_guess",
  "minijinja",
+ "monoio",
  "rayon",
  "reqwest",
  "rustc-hash",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.6.3",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -1054,6 +1155,19 @@ dependencies = [
  "urlencoding",
  "walkdir",
  "zstd",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1107,6 +1221,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1164,7 +1284,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1202,7 +1322,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1283,7 +1403,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1369,7 +1489,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1487,7 +1607,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1598,6 +1718,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -1661,7 +1791,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -1771,10 +1901,10 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1856,7 +1986,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2146,7 +2276,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2236,6 +2366,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2274,6 +2413,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2317,6 +2471,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2335,6 +2495,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2350,6 +2516,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2383,6 +2555,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2398,6 +2576,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2419,6 +2603,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2434,6 +2624,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2511,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dashmap = "6.1"
 flate2 = "1.1"
 rustc-hash = "2"
 http-body-util = "0.1"
+httparse = "1.9"
 httpdate = "1"
 hyper = { version = "1.9", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["http1", "server", "tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,14 @@ tokio-test = "0.4"
 [target.'cfg(target_env = "musl")'.dependencies]
 mimalloc = "0.1.43"
 
+# io_uring engine (Linux only, opt-in via `--features uring`). Kept out of
+# default and macOS builds so they stay lean.
+[target.'cfg(target_os = "linux")'.dependencies]
+monoio = { version = "0.2", features = ["bytes"], optional = true }
+
+[features]
+uring = ["dep:monoio"]
+
 [lints.clippy]
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -57,8 +57,9 @@ cleanup() { [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
 start_server() {
-  echo "→ serve $BIN on :$PORT"
-  "$BIN" serve "$FIXTURES" --port "$PORT" --log-level error >/dev/null 2>&1 &
+  echo "→ serve $BIN on :$PORT (engine=${BENCH_ENGINE:-hyper})"
+  "$BIN" serve "$FIXTURES" --port "$PORT" --log-level error \
+    --engine "${BENCH_ENGINE:-hyper}" >/dev/null 2>&1 &
   SERVER_PID=$!
   for _ in $(seq 1 50); do
     curl -fsS "http://127.0.0.1:$PORT/_health" >/dev/null 2>&1 && return 0

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,10 @@ impl Cli {
                 let engine = match engine.as_str() {
                     "hyper" => crate::server::Engine::Hyper,
                     "raw" => crate::server::Engine::Raw,
-                    other => anyhow::bail!("unknown --engine '{other}' (expected hyper or raw)"),
+                    "uring" => crate::server::Engine::Uring,
+                    other => {
+                        anyhow::bail!("unknown --engine '{other}' (expected hyper, raw, or uring)")
+                    }
                 };
 
                 // Use subcommand values or fall back to global defaults

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,10 @@ pub enum Commands {
         #[arg(long = "log-requests")]
         #[arg(help = "Log HTTP requests")]
         log_requests: bool,
+
+        #[arg(long = "engine", default_value = "hyper")]
+        #[arg(help = "Request engine: hyper (production) or raw (experimental)")]
+        engine: String,
     },
     #[command(about = "Show version information")]
     Version,
@@ -111,9 +115,16 @@ impl Cli {
                 log_level,
                 log_format,
                 log_requests,
+                engine,
             }) => {
                 let public_dir = self.dir.clone();
                 let serve_dir = directory.clone().unwrap_or(public_dir);
+
+                let engine = match engine.as_str() {
+                    "hyper" => crate::server::Engine::Hyper,
+                    "raw" => crate::server::Engine::Raw,
+                    other => anyhow::bail!("unknown --engine '{other}' (expected hyper or raw)"),
+                };
 
                 // Use subcommand values or fall back to global defaults
                 let final_log_level = log_level.unwrap_or(self.log_level);
@@ -129,6 +140,7 @@ impl Cli {
                     spa_mode: spa || self.spa,
                     config_prefix: config_prefix.unwrap_or(self.config_prefix),
                     log_requests: log_requests || self.log_requests,
+                    engine,
                 })
                 .await
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,87 @@
+//! The transport-agnostic core every fast engine shares.
+//!
+//! A request handler is just: parse bytes into [`Request`], call [`route`], write
+//! the resulting [`Reply`]. `route` makes the entire HTTP decision — method, path
+//! sanitation, encoding, conditional, SPA fallback — and returns *precomputed
+//! bytes to write*. It allocates nothing on the hit path and knows nothing about
+//! sockets, runtimes, or `io_uring`. Each engine (tokio/kqueue, `io_uring`, …)
+//! only supplies the read and the write in its platform's dialect.
+
+use crate::response_buffer::ResponseBuffer;
+use crate::routes::NanoWeb;
+use std::sync::Arc;
+
+// Fully static responses — no per-request formatting. Content-Length is baked in.
+pub const NOT_FOUND: &[u8] =
+    b"HTTP/1.1 404 Not Found\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 9\r\n\r\nNot Found";
+pub const BAD_REQUEST: &[u8] =
+    b"HTTP/1.1 400 Bad Request\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 11\r\n\r\nBad Request";
+pub const METHOD_NOT_ALLOWED: &[u8] =
+    b"HTTP/1.1 405 Method Not Allowed\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 18\r\n\r\nMethod Not Allowed";
+pub const HEALTH: &[u8] =
+    b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 15\r\n\r\n{\"status\":\"ok\"}";
+
+/// A request reduced to only what routing needs. All fields borrow the engine's
+/// read buffer — no copies.
+pub struct Request<'a> {
+    pub method: &'a str,
+    /// Raw request target, query string included (`route` strips it).
+    pub path: &'a str,
+    pub accept_encoding: &'a str,
+    pub if_none_match: Option<&'a str>,
+}
+
+/// What to put on the wire. Every variant is precomputed bytes — the engine just
+/// writes them. No allocation, no formatting.
+pub enum Reply {
+    /// 200: write `buf.head`, then `buf.body` unless `body` is false (HEAD).
+    Ok {
+        buf: Arc<ResponseBuffer>,
+        body: bool,
+    },
+    /// 304: write `buf.head_304` (validators only).
+    NotModified { buf: Arc<ResponseBuffer> },
+    /// Fixed response (404/400/405/health) — fully static bytes.
+    Static(&'static [u8]),
+}
+
+/// The shared routing decision. Allocation-free on the hit path; the only possible
+/// allocation is the trailing-slash retry key on a miss.
+pub fn route(server: &NanoWeb, req: &Request, spa: bool) -> Reply {
+    let is_head = req.method == "HEAD";
+    if req.method != "GET" && !is_head {
+        return Reply::Static(METHOD_NOT_ALLOWED);
+    }
+
+    let path = req.path.split('?').next().unwrap_or("/");
+    if path == "/_health" {
+        return Reply::Static(HEALTH);
+    }
+
+    let Ok(path) = crate::path::validate_request_path(path) else {
+        return Reply::Static(BAD_REQUEST);
+    };
+
+    let mut rb = server.get_response(&path, req.accept_encoding);
+    if rb.is_none() && !path.ends_with('/') {
+        rb = server.get_response(&format!("{path}/"), req.accept_encoding);
+    }
+    if rb.is_none() && spa {
+        rb = server.get_response("/", req.accept_encoding);
+    }
+
+    match rb {
+        Some(buf) => {
+            if let Some(inm) = req.if_none_match {
+                if inm == buf.etag.as_ref() {
+                    return Reply::NotModified { buf };
+                }
+            }
+            Reply::Ok {
+                buf,
+                body: !is_head,
+            }
+        }
+        None => Reply::Static(NOT_FOUND),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod compression;
+pub mod engine;
 pub mod mime_types;
 pub mod path;
 pub mod raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ pub mod routes;
 pub mod server;
 pub mod template;
 
+#[cfg(all(target_os = "linux", feature = "uring"))]
+pub mod uring;
+
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 pub fn init_logging(level: &str, format: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod compression;
 pub mod mime_types;
 pub mod path;
+pub mod raw;
 pub mod response_buffer;
 pub mod routes;
 pub mod server;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -161,12 +161,41 @@ async fn respond(
                     return Ok(());
                 }
             }
-            stream.write_all(&b.head).await?;
-            if !is_head {
-                stream.write_all(&b.body).await?;
+            if is_head {
+                stream.write_all(&b.head).await?;
+            } else {
+                // One writev for head+body. Two write_all calls would be two
+                // syscalls (and, with TCP_NODELAY, two segments) — which is
+                // exactly what made the previous cut lose ~18% on bodied GETs.
+                write_head_body(stream, &b.head, &b.body).await?;
             }
         }
         None => stream.write_all(NOT_FOUND).await?,
+    }
+    Ok(())
+}
+
+/// Write `head` then `body` in a single `writev` where the OS allows it, looping
+/// only to drain partial writes (large bodies). `TcpStream` reports vectored
+/// support, so small responses leave in one syscall with no copy and no extra
+/// allocation.
+async fn write_head_body(stream: &mut TcpStream, head: &[u8], body: &[u8]) -> std::io::Result<()> {
+    use std::io::IoSlice;
+    let total = head.len() + body.len();
+    let mut off = 0usize;
+    while off < total {
+        let (h, b) = if off < head.len() {
+            (&head[off..], body)
+        } else {
+            (&[][..], &body[off - head.len()..])
+        };
+        let n = stream
+            .write_vectored(&[IoSlice::new(h), IoSlice::new(b)])
+            .await?;
+        if n == 0 {
+            return Err(std::io::ErrorKind::WriteZero.into());
+        }
+        off += n;
     }
     Ok(())
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,185 @@
+//! Experimental hand-rolled HTTP/1.1 engine.
+//!
+//! No HTTP library in the hot path: parse just enough of the request with
+//! `httparse`, look up the precomputed `ResponseBuffer`, and write its
+//! pre-serialized `head` (and `body` for GET) straight to the socket. This is
+//! the userspace half of the "precomputed bytes → socket" idea — the part that
+//! runs without `io_uring`, so it can be measured on any platform.
+//!
+//! Deliberately omits: dev-mode reload, request logging, and a Date header.
+//! It exists to measure the ceiling of the no-library path, not to replace the
+//! production engine.
+
+use crate::routes::NanoWeb;
+use crate::server::{create_reuse_port_listener, ServeConfig};
+use anyhow::Result;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, info};
+
+const NOT_FOUND: &[u8] =
+    b"HTTP/1.1 404 Not Found\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 9\r\n\r\nNot Found";
+const BAD_REQUEST: &[u8] =
+    b"HTTP/1.1 400 Bad Request\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 11\r\n\r\nBad Request";
+const METHOD_NOT_ALLOWED: &[u8] =
+    b"HTTP/1.1 405 Method Not Allowed\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 18\r\n\r\nMethod Not Allowed";
+
+pub async fn start_server(config: ServeConfig) -> Result<()> {
+    let server = Arc::new(NanoWeb::new());
+    server.populate_routes(&config.public_dir, &config.config_prefix)?;
+    info!("Routes loaded: {} (raw engine)", server.route_count());
+
+    let addr: SocketAddr = ([0, 0, 0, 0], config.port).into();
+    let listener = TcpListener::from_std(create_reuse_port_listener(addr)?)?;
+    info!("Starting server on http://{} (raw engine)", addr);
+
+    let spa = config.spa_mode;
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let (stream, _) = accepted?;
+                let server = server.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_conn(stream, &server, spa).await {
+                        debug!("connection error: {e}");
+                    }
+                });
+            }
+            () = shutdown() => {
+                info!("Shutdown signal received, stopping server");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn shutdown() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Serve requests on a single keep-alive connection until the client closes,
+/// sends `Connection: close`, or errors.
+async fn handle_conn(mut stream: TcpStream, server: &NanoWeb, spa: bool) -> Result<()> {
+    let _ = stream.set_nodelay(true);
+    let mut buf = vec![0u8; 8192];
+    let mut len = 0usize;
+
+    loop {
+        // Accumulate bytes until a full request head parses.
+        let (consumed, keep_alive) = loop {
+            let mut headers = [httparse::EMPTY_HEADER; 32];
+            let mut req = httparse::Request::new(&mut headers);
+            let mut done: Option<(usize, bool)> = None;
+
+            match req.parse(&buf[..len])? {
+                httparse::Status::Complete(n) => {
+                    let keep_alive = !connection_close(&req);
+                    respond(&mut stream, server, &req, spa).await?;
+                    done = Some((n, keep_alive));
+                }
+                httparse::Status::Partial => {}
+            }
+            // `req`/`headers` borrow `buf`; they drop here, before we touch buf.
+            if let Some(d) = done {
+                break d;
+            }
+
+            if len == buf.len() {
+                buf.resize(len * 2, 0);
+            }
+            let n = stream.read(&mut buf[len..]).await?;
+            if n == 0 {
+                return Ok(()); // client closed (cleanly if mid-idle)
+            }
+            len += n;
+        };
+
+        // Drop the consumed request, keep any pipelined leftover for the next loop.
+        buf.copy_within(consumed..len, 0);
+        len -= consumed;
+
+        if !keep_alive {
+            return Ok(());
+        }
+    }
+}
+
+async fn respond(
+    stream: &mut TcpStream,
+    server: &NanoWeb,
+    req: &httparse::Request<'_, '_>,
+    spa: bool,
+) -> Result<()> {
+    let method = req.method.unwrap_or("");
+    let is_head = method == "HEAD";
+    if method != "GET" && !is_head {
+        stream.write_all(METHOD_NOT_ALLOWED).await?;
+        return Ok(());
+    }
+
+    // httparse path includes the query string; strip it like hyper's uri().path().
+    let raw_path = req.path.unwrap_or("/");
+    let raw_path = raw_path.split('?').next().unwrap_or("/");
+
+    if raw_path == "/_health" {
+        let body = br#"{"status":"ok"}"#;
+        let head = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(head.as_bytes()).await?;
+        stream.write_all(body).await?;
+        return Ok(());
+    }
+
+    let Ok(path) = crate::path::validate_request_path(raw_path) else {
+        stream.write_all(BAD_REQUEST).await?;
+        return Ok(());
+    };
+
+    let accept_encoding = header(req, "accept-encoding").unwrap_or("");
+    let mut rb = server.get_response(&path, accept_encoding);
+    if rb.is_none() && !path.ends_with('/') {
+        rb = server.get_response(&format!("{path}/"), accept_encoding);
+    }
+    if rb.is_none() && spa {
+        rb = server.get_response("/", accept_encoding);
+    }
+
+    match rb {
+        Some(b) => {
+            // ETag conditional → 304 with the minimal validator header set.
+            if let Some(inm) = header(req, "if-none-match") {
+                if inm == b.etag.as_ref() {
+                    let head = format!(
+                        "HTTP/1.1 304 Not Modified\r\netag: {}\r\ncache-control: {}\r\n\r\n",
+                        b.etag, b.cache_control
+                    );
+                    stream.write_all(head.as_bytes()).await?;
+                    return Ok(());
+                }
+            }
+            stream.write_all(&b.head).await?;
+            if !is_head {
+                stream.write_all(&b.body).await?;
+            }
+        }
+        None => stream.write_all(NOT_FOUND).await?,
+    }
+    Ok(())
+}
+
+/// Case-insensitive header lookup against the parsed request.
+fn header<'a>(req: &'a httparse::Request, name: &str) -> Option<&'a str> {
+    req.headers
+        .iter()
+        .find(|h| h.name.eq_ignore_ascii_case(name))
+        .and_then(|h| std::str::from_utf8(h.value).ok())
+}
+
+/// HTTP/1.1 keeps connections alive unless the client says otherwise.
+fn connection_close(req: &httparse::Request) -> bool {
+    header(req, "connection").is_some_and(|v| v.eq_ignore_ascii_case("close"))
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -10,6 +10,7 @@
 //! It exists to measure the ceiling of the no-library path, not to replace the
 //! production engine.
 
+use crate::engine::{self, Reply};
 use crate::routes::NanoWeb;
 use crate::server::{create_reuse_port_listener, ServeConfig};
 use anyhow::Result;
@@ -18,13 +19,6 @@ use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, info};
-
-const NOT_FOUND: &[u8] =
-    b"HTTP/1.1 404 Not Found\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 9\r\n\r\nNot Found";
-const BAD_REQUEST: &[u8] =
-    b"HTTP/1.1 400 Bad Request\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 11\r\n\r\nBad Request";
-const METHOD_NOT_ALLOWED: &[u8] =
-    b"HTTP/1.1 405 Method Not Allowed\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 18\r\n\r\nMethod Not Allowed";
 
 pub async fn start_server(config: ServeConfig) -> Result<()> {
     let server = Arc::new(NanoWeb::new());
@@ -112,65 +106,21 @@ async fn respond(
     req: &httparse::Request<'_, '_>,
     spa: bool,
 ) -> Result<()> {
-    let method = req.method.unwrap_or("");
-    let is_head = method == "HEAD";
-    if method != "GET" && !is_head {
-        stream.write_all(METHOD_NOT_ALLOWED).await?;
-        return Ok(());
-    }
-
-    // httparse path includes the query string; strip it like hyper's uri().path().
-    let raw_path = req.path.unwrap_or("/");
-    let raw_path = raw_path.split('?').next().unwrap_or("/");
-
-    if raw_path == "/_health" {
-        let body = br#"{"status":"ok"}"#;
-        let head = format!(
-            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
-            body.len()
-        );
-        stream.write_all(head.as_bytes()).await?;
-        stream.write_all(body).await?;
-        return Ok(());
-    }
-
-    let Ok(path) = crate::path::validate_request_path(raw_path) else {
-        stream.write_all(BAD_REQUEST).await?;
-        return Ok(());
+    // Extract the four fields routing needs, then let the shared core decide.
+    let parsed = engine::Request {
+        method: req.method.unwrap_or(""),
+        path: req.path.unwrap_or("/"),
+        accept_encoding: header(req, "accept-encoding").unwrap_or(""),
+        if_none_match: header(req, "if-none-match"),
     };
 
-    let accept_encoding = header(req, "accept-encoding").unwrap_or("");
-    let mut rb = server.get_response(&path, accept_encoding);
-    if rb.is_none() && !path.ends_with('/') {
-        rb = server.get_response(&format!("{path}/"), accept_encoding);
-    }
-    if rb.is_none() && spa {
-        rb = server.get_response("/", accept_encoding);
-    }
-
-    match rb {
-        Some(b) => {
-            // ETag conditional → 304 with the minimal validator header set.
-            if let Some(inm) = header(req, "if-none-match") {
-                if inm == b.etag.as_ref() {
-                    let head = format!(
-                        "HTTP/1.1 304 Not Modified\r\netag: {}\r\ncache-control: {}\r\n\r\n",
-                        b.etag, b.cache_control
-                    );
-                    stream.write_all(head.as_bytes()).await?;
-                    return Ok(());
-                }
-            }
-            if is_head {
-                stream.write_all(&b.head).await?;
-            } else {
-                // One writev for head+body. Two write_all calls would be two
-                // syscalls (and, with TCP_NODELAY, two segments) — which is
-                // exactly what made the previous cut lose ~18% on bodied GETs.
-                write_head_body(stream, &b.head, &b.body).await?;
-            }
-        }
-        None => stream.write_all(NOT_FOUND).await?,
+    match engine::route(server, &parsed, spa) {
+        // One writev for head+body — two write_all calls would be two syscalls
+        // (and two segments under TCP_NODELAY), which cost ~18% on bodied GETs.
+        Reply::Ok { buf, body: true } => write_head_body(stream, &buf.head, &buf.body).await?,
+        Reply::Ok { buf, body: false } => stream.write_all(&buf.head).await?,
+        Reply::NotModified { buf } => stream.write_all(&buf.head_304).await?,
+        Reply::Static(bytes) => stream.write_all(bytes).await?,
     }
     Ok(())
 }

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -76,6 +76,10 @@ pub struct ResponseBuffer {
     /// creation so the hot path clones it instead of re-inserting ~13 headers
     /// per request. The body is appended by the server (or dropped for HEAD).
     pub headers: HeaderMap,
+    /// Pre-serialized HTTP/1.1 response head ("HTTP/1.1 200 OK\r\n" + headers +
+    /// "\r\n"), ready to write to a socket verbatim. Used by the raw engine,
+    /// which writes `head` then `body` with no per-request formatting at all.
+    pub head: Bytes,
 }
 
 impl ResponseBuffer {
@@ -98,6 +102,7 @@ impl ResponseBuffer {
             &content_length,
             vary_encoding,
         );
+        let head = serialize_head(&headers);
         Self {
             body,
             content_type,
@@ -108,8 +113,26 @@ impl ResponseBuffer {
             content_length,
             vary_encoding,
             headers,
+            head,
         }
     }
+}
+
+/// Serialize the 200-response status line + header block to raw bytes, ready to
+/// write to a socket. Date is intentionally omitted — the raw engine serves
+/// immutable precomputed bytes and cannot stamp a live date without per-request
+/// work, which is the whole point of avoiding.
+fn serialize_head(headers: &HeaderMap) -> Bytes {
+    let mut buf = Vec::with_capacity(320);
+    buf.extend_from_slice(b"HTTP/1.1 200 OK\r\n");
+    for (name, value) in headers {
+        buf.extend_from_slice(name.as_str().as_bytes());
+        buf.extend_from_slice(b": ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+    buf.extend_from_slice(b"\r\n");
+    Bytes::from(buf)
 }
 
 /// Build the complete 200-response header block. All values are server-controlled

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -83,6 +83,13 @@ pub struct ResponseBuffer {
     /// Pre-serialized `304 Not Modified` response (validators only), so the
     /// conditional path is a single verbatim write — no per-request `format!`.
     pub head_304: Bytes,
+    /// Full 200 response (head + body) as one contiguous buffer, so the `io_uring`
+    /// engine serves a bodied GET in a single syscall/SQE and a single segment —
+    /// monoio can't cheaply do a zero-copy vectored write of two `Bytes`, so we
+    /// trade memory (a second copy of the body) for one write. Built only in
+    /// uring builds; the tokio engine uses `writev` over `head`+`body` instead.
+    #[cfg(all(target_os = "linux", feature = "uring"))]
+    pub wire: Bytes,
 }
 
 impl ResponseBuffer {
@@ -107,6 +114,13 @@ impl ResponseBuffer {
         );
         let head = serialize_head(&headers);
         let head_304 = serialize_304(&etag, &cache_control);
+        #[cfg(all(target_os = "linux", feature = "uring"))]
+        let wire = {
+            let mut v = Vec::with_capacity(head.len() + body.len());
+            v.extend_from_slice(&head);
+            v.extend_from_slice(&body);
+            Bytes::from(v)
+        };
         Self {
             body,
             content_type,
@@ -119,6 +133,8 @@ impl ResponseBuffer {
             headers,
             head,
             head_304,
+            #[cfg(all(target_os = "linux", feature = "uring"))]
+            wire,
         }
     }
 }

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -80,6 +80,9 @@ pub struct ResponseBuffer {
     /// "\r\n"), ready to write to a socket verbatim. Used by the raw engine,
     /// which writes `head` then `body` with no per-request formatting at all.
     pub head: Bytes,
+    /// Pre-serialized `304 Not Modified` response (validators only), so the
+    /// conditional path is a single verbatim write — no per-request `format!`.
+    pub head_304: Bytes,
 }
 
 impl ResponseBuffer {
@@ -103,6 +106,7 @@ impl ResponseBuffer {
             vary_encoding,
         );
         let head = serialize_head(&headers);
+        let head_304 = serialize_304(&etag, &cache_control);
         Self {
             body,
             content_type,
@@ -114,8 +118,20 @@ impl ResponseBuffer {
             vary_encoding,
             headers,
             head,
+            head_304,
         }
     }
+}
+
+/// Pre-serialize the `304 Not Modified` response (validators only).
+fn serialize_304(etag: &str, cache_control: &str) -> Bytes {
+    let mut buf = Vec::with_capacity(96);
+    buf.extend_from_slice(b"HTTP/1.1 304 Not Modified\r\netag: ");
+    buf.extend_from_slice(etag.as_bytes());
+    buf.extend_from_slice(b"\r\ncache-control: ");
+    buf.extend_from_slice(cache_control.as_bytes());
+    buf.extend_from_slice(b"\r\n\r\n");
+    Bytes::from(buf)
 }
 
 /// Serialize the 200-response status line + header block to raw bytes, ready to

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,7 +13,9 @@ use std::time::SystemTime;
 use tracing::{debug, error, info};
 use walkdir::WalkDir;
 
-type RouteMap = DashMap<Arc<str>, ResponseBuffer, FxBuildHasher>;
+// Values are Arc so the hot path clones one refcount, not the whole struct (body +
+// 5 Arc<str> + a 13-entry HeaderMap). Routes are write-once at startup / dev-reload.
+type RouteMap = DashMap<Arc<str>, Arc<ResponseBuffer>, FxBuildHasher>;
 
 #[derive(Debug, Clone)]
 struct CachedRoute {
@@ -50,15 +52,15 @@ impl ResponseCache {
         }
     }
 
-    fn get(&self, path: &str, encoding: Encoding) -> Option<ResponseBuffer> {
+    fn get(&self, path: &str, encoding: Encoding) -> Option<Arc<ResponseBuffer>> {
         // Try requested encoding first, fallback to identity for non-compressible files
         self.get_map(encoding)
             .get(path)
             .or_else(|| self.identity.get(path))
-            .map(|e| e.value().clone())
+            .map(|e| Arc::clone(e.value()))
     }
 
-    fn insert(&self, path: Arc<str>, encoding: Encoding, buf: ResponseBuffer) {
+    fn insert(&self, path: Arc<str>, encoding: Encoding, buf: Arc<ResponseBuffer>) {
         self.get_map(encoding).insert(path, buf);
     }
 }
@@ -86,7 +88,7 @@ impl NanoWeb {
         self.routes.len()
     }
 
-    pub fn get_response(&self, path: &str, accept_encoding: &str) -> Option<ResponseBuffer> {
+    pub fn get_response(&self, path: &str, accept_encoding: &str) -> Option<Arc<ResponseBuffer>> {
         let encoding = Encoding::from_accept_encoding(accept_encoding);
         self.responses.get(path, encoding)
     }
@@ -192,7 +194,7 @@ impl NanoWeb {
         self.responses.insert(
             url_path.clone(),
             Encoding::Identity,
-            ResponseBuffer::new(
+            Arc::new(ResponseBuffer::new(
                 compressed.plain.clone(),
                 ct.clone(),
                 None,
@@ -200,14 +202,14 @@ impl NanoWeb {
                 lm.clone(),
                 cc.clone(),
                 vary,
-            ),
+            )),
         );
 
         if let Some(data) = &compressed.gzip {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Gzip,
-                ResponseBuffer::new(
+                Arc::new(ResponseBuffer::new(
                     data.clone(),
                     ct.clone(),
                     Some("gzip"),
@@ -215,7 +217,7 @@ impl NanoWeb {
                     lm.clone(),
                     cc.clone(),
                     vary,
-                ),
+                )),
             );
         }
 
@@ -223,7 +225,7 @@ impl NanoWeb {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Brotli,
-                ResponseBuffer::new(
+                Arc::new(ResponseBuffer::new(
                     data.clone(),
                     ct.clone(),
                     Some("br"),
@@ -231,7 +233,7 @@ impl NanoWeb {
                     lm.clone(),
                     cc.clone(),
                     vary,
-                ),
+                )),
             );
         }
 
@@ -239,7 +241,7 @@ impl NanoWeb {
             self.responses.insert(
                 url_path.clone(),
                 Encoding::Zstd,
-                ResponseBuffer::new(
+                Arc::new(ResponseBuffer::new(
                     data.clone(),
                     ct.clone(),
                     Some("zstd"),
@@ -247,7 +249,7 @@ impl NanoWeb {
                     lm.clone(),
                     cc.clone(),
                     vary,
-                ),
+                )),
             );
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,16 @@ use tracing::{debug, info, warn};
 
 use crate::routes::NanoWeb;
 
+/// Request-handling engine. `Hyper` is the production path; `Raw` is an
+/// experimental hand-rolled HTTP/1.1 loop that writes precomputed response
+/// bytes with no library in the hot path (see `crate::raw`).
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum Engine {
+    #[default]
+    Hyper,
+    Raw,
+}
+
 #[derive(Clone)]
 pub struct ServeConfig {
     pub public_dir: PathBuf,
@@ -22,6 +32,7 @@ pub struct ServeConfig {
     pub spa_mode: bool,
     pub config_prefix: String,
     pub log_requests: bool,
+    pub engine: Engine,
 }
 
 struct AppState {
@@ -30,7 +41,7 @@ struct AppState {
 }
 
 /// Create a TCP listener with `SO_REUSEPORT` for better multi-core scaling
-fn create_reuse_port_listener(addr: SocketAddr) -> Result<std::net::TcpListener> {
+pub(crate) fn create_reuse_port_listener(addr: SocketAddr) -> Result<std::net::TcpListener> {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
     socket.set_reuse_address(true)?;
     #[cfg(unix)]
@@ -42,6 +53,10 @@ fn create_reuse_port_listener(addr: SocketAddr) -> Result<std::net::TcpListener>
 }
 
 pub async fn start_server(config: ServeConfig) -> Result<()> {
+    if config.engine == Engine::Raw {
+        return crate::raw::start_server(config).await;
+    }
+
     let server = Arc::new(NanoWeb::new());
     server.populate_routes(&config.public_dir, &config.config_prefix)?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,8 @@ pub enum Engine {
     #[default]
     Hyper,
     Raw,
+    /// `io_uring` (Linux only, built with `--features uring`).
+    Uring,
 }
 
 #[derive(Clone)]
@@ -55,6 +57,17 @@ pub(crate) fn create_reuse_port_listener(addr: SocketAddr) -> Result<std::net::T
 pub async fn start_server(config: ServeConfig) -> Result<()> {
     if config.engine == Engine::Raw {
         return crate::raw::start_server(config).await;
+    }
+    if config.engine == Engine::Uring {
+        #[cfg(all(target_os = "linux", feature = "uring"))]
+        {
+            // monoio owns its own per-core runtimes; this blocks until shutdown.
+            return crate::uring::start_server(config);
+        }
+        #[cfg(not(all(target_os = "linux", feature = "uring")))]
+        {
+            anyhow::bail!("io_uring engine requires Linux and `--features uring`");
+        }
     }
 
     let server = Arc::new(NanoWeb::new());

--- a/src/server.rs
+++ b/src/server.rs
@@ -220,7 +220,7 @@ fn handle_request(
                     .expect("304 response"));
             }
         }
-        build_response(b, is_head)
+        build_response(b.as_ref(), is_head)
     } else {
         debug!("Route not found: {path}");
         response(StatusCode::NOT_FOUND, "Not Found")

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,7 +62,7 @@ pub async fn start_server(config: ServeConfig) -> Result<()> {
         #[cfg(all(target_os = "linux", feature = "uring"))]
         {
             // monoio owns its own per-core runtimes; this blocks until shutdown.
-            return crate::uring::start_server(config);
+            return crate::uring::start_server(&config);
         }
         #[cfg(not(all(target_os = "linux", feature = "uring")))]
         {

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -9,6 +9,7 @@
 
 use crate::engine::{self, Reply};
 use crate::routes::NanoWeb;
+use bytes::Bytes;
 use crate::server::{create_reuse_port_listener, ServeConfig};
 use anyhow::Result;
 use monoio::io::{AsyncReadRent, AsyncWriteRentExt};
@@ -83,16 +84,15 @@ async fn handle_conn(mut stream: TcpStream, server: Arc<NanoWeb>, spa: bool) {
         let keep_alive = !connection_close(&req);
 
         let write_ok = match engine::route(&server, &parsed, spa) {
-            Reply::Ok { buf: rb, body } => {
-                let ok = write_all(&mut stream, rb.head.clone()).await;
-                if ok && body {
-                    write_all(&mut stream, rb.body.clone()).await
-                } else {
-                    ok
-                }
-            }
+            // Single write of the precomputed contiguous wire (head + body) — one
+            // io_uring submit, one TCP segment. Two separate write_all calls would
+            // be two ring round-trips and two segments under TCP_NODELAY (the
+            // tail-latency regression Track 2 found). The Bytes clone is an Arc bump.
+            Reply::Ok { buf: rb, body: true } => write_all(&mut stream, rb.wire.clone()).await,
+            Reply::Ok { buf: rb, body: false } => write_all(&mut stream, rb.head.clone()).await,
             Reply::NotModified { buf: rb } => write_all(&mut stream, rb.head_304.clone()).await,
-            Reply::Static(bytes) => write_all(&mut stream, bytes.to_vec()).await,
+            // from_static is zero-copy — no per-request allocation on error paths.
+            Reply::Static(bytes) => write_all(&mut stream, Bytes::from_static(bytes)).await,
         };
 
         if !write_ok || !keep_alive {

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -1,8 +1,8 @@
-//! io_uring engine (Linux), via monoio. Thread-per-core, shared-nothing:
+//! `io_uring` engine (Linux), via monoio. Thread-per-core, shared-nothing:
 //! one monoio runtime per core, each with its own `SO_REUSEPORT` listener and a
 //! shared read-only `Arc<NanoWeb>`. The request handling is identical to every
 //! other engine — extract four fields, call [`engine::route`], write the
-//! [`Reply`] — only the read/write go through io_uring instead of epoll.
+//! [`Reply`] — only the read/write go through `io_uring` instead of epoll.
 //!
 //! This is the Linux half of the platform split; macOS uses the tokio/kqueue
 //! engine in `raw`. The only difference is the transport.
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::info;
 
-pub fn start_server(config: ServeConfig) -> Result<()> {
+pub fn start_server(config: &ServeConfig) -> Result<()> {
     let server = Arc::new(NanoWeb::new());
     server.populate_routes(&config.public_dir, &config.config_prefix)?;
     info!("Routes loaded: {} (io_uring engine)", server.route_count());
@@ -101,7 +101,7 @@ async fn handle_conn(mut stream: TcpStream, server: Arc<NanoWeb>, spa: bool) {
     }
 }
 
-/// Write an owned buffer fully via io_uring. Returns false on error.
+/// Write an owned buffer fully via `io_uring`. Returns false on error.
 async fn write_all<T: monoio::buf::IoBuf>(stream: &mut TcpStream, data: T) -> bool {
     let (res, _) = stream.write_all(data).await;
     res.is_ok()

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -1,0 +1,119 @@
+//! io_uring engine (Linux), via monoio. Thread-per-core, shared-nothing:
+//! one monoio runtime per core, each with its own `SO_REUSEPORT` listener and a
+//! shared read-only `Arc<NanoWeb>`. The request handling is identical to every
+//! other engine — extract four fields, call [`engine::route`], write the
+//! [`Reply`] — only the read/write go through io_uring instead of epoll.
+//!
+//! This is the Linux half of the platform split; macOS uses the tokio/kqueue
+//! engine in `raw`. The only difference is the transport.
+
+use crate::engine::{self, Reply};
+use crate::routes::NanoWeb;
+use crate::server::{create_reuse_port_listener, ServeConfig};
+use anyhow::Result;
+use monoio::io::{AsyncReadRent, AsyncWriteRentExt};
+use monoio::net::{TcpListener, TcpStream};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tracing::info;
+
+pub fn start_server(config: ServeConfig) -> Result<()> {
+    let server = Arc::new(NanoWeb::new());
+    server.populate_routes(&config.public_dir, &config.config_prefix)?;
+    info!("Routes loaded: {} (io_uring engine)", server.route_count());
+
+    let cores = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+    let addr: SocketAddr = ([0, 0, 0, 0], config.port).into();
+    info!("Starting server on http://{addr} (io_uring engine, {cores} shards)");
+
+    let mut handles = Vec::with_capacity(cores);
+    for _ in 0..cores {
+        let server = server.clone();
+        let spa = config.spa_mode;
+        // One SO_REUSEPORT listener per shard; the kernel load-balances accepts.
+        let std_listener = create_reuse_port_listener(addr)?;
+        handles.push(std::thread::spawn(move || {
+            let mut rt = monoio::RuntimeBuilder::<monoio::IoUringDriver>::new()
+                .build()
+                .expect("build monoio runtime");
+            rt.block_on(shard(std_listener, server, spa));
+        }));
+    }
+    for h in handles {
+        let _ = h.join();
+    }
+    Ok(())
+}
+
+async fn shard(std_listener: std::net::TcpListener, server: Arc<NanoWeb>, spa: bool) {
+    let listener = TcpListener::from_std(std_listener).expect("monoio from_std");
+    while let Ok((stream, _)) = listener.accept().await {
+        let server = server.clone();
+        monoio::spawn(handle_conn(stream, server, spa));
+    }
+}
+
+async fn handle_conn(mut stream: TcpStream, server: Arc<NanoWeb>, spa: bool) {
+    let _ = stream.set_nodelay(true);
+    let mut buf = vec![0u8; 8192];
+
+    loop {
+        // io_uring read: buffer is moved in and handed back.
+        let (res, b) = stream.read(buf).await;
+        buf = b;
+        let n = match res {
+            Ok(0) | Err(_) => return,
+            Ok(n) => n,
+        };
+
+        let mut headers = [httparse::EMPTY_HEADER; 32];
+        let mut req = httparse::Request::new(&mut headers);
+        // Benchmark/keep-alive clients send a whole request per packet; on a partial
+        // or malformed parse we just close (no accumulation buffer here yet).
+        if !matches!(req.parse(&buf[..n]), Ok(httparse::Status::Complete(_))) {
+            return;
+        }
+
+        let parsed = engine::Request {
+            method: req.method.unwrap_or(""),
+            path: req.path.unwrap_or("/"),
+            accept_encoding: header(&req, "accept-encoding").unwrap_or(""),
+            if_none_match: header(&req, "if-none-match"),
+        };
+        let keep_alive = !connection_close(&req);
+
+        let write_ok = match engine::route(&server, &parsed, spa) {
+            Reply::Ok { buf: rb, body } => {
+                let ok = write_all(&mut stream, rb.head.clone()).await;
+                if ok && body {
+                    write_all(&mut stream, rb.body.clone()).await
+                } else {
+                    ok
+                }
+            }
+            Reply::NotModified { buf: rb } => write_all(&mut stream, rb.head_304.clone()).await,
+            Reply::Static(bytes) => write_all(&mut stream, bytes.to_vec()).await,
+        };
+
+        if !write_ok || !keep_alive {
+            return;
+        }
+    }
+}
+
+/// Write an owned buffer fully via io_uring. Returns false on error.
+async fn write_all<T: monoio::buf::IoBuf>(stream: &mut TcpStream, data: T) -> bool {
+    let (res, _) = stream.write_all(data).await;
+    res.is_ok()
+}
+
+fn header<'a>(req: &'a httparse::Request, name: &str) -> Option<&'a str> {
+    req.headers
+        .iter()
+        .find(|h| h.name.eq_ignore_ascii_case(name))
+        .and_then(|h| std::str::from_utf8(h.value).ok())
+}
+
+fn connection_close(req: &httparse::Request) -> bool {
+    header(req, "connection").is_some_and(|v| v.eq_ignore_ascii_case("close"))
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,7 @@ use reqwest::StatusCode;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::{sleep, Duration};
 
 /// Bind to port 0 and let the OS assign a free port, avoiding collisions in parallel test runs.
@@ -20,6 +21,22 @@ fn create_test_server(
     spa_mode: bool,
     dev_mode: bool,
 ) -> tokio::task::JoinHandle<()> {
+    create_test_server_engine(
+        temp_dir,
+        port,
+        spa_mode,
+        dev_mode,
+        nano_web::server::Engine::Hyper,
+    )
+}
+
+fn create_test_server_engine(
+    temp_dir: &Path,
+    port: u16,
+    spa_mode: bool,
+    dev_mode: bool,
+    engine: nano_web::server::Engine,
+) -> tokio::task::JoinHandle<()> {
     let config = nano_web::server::ServeConfig {
         public_dir: temp_dir.to_path_buf(),
         port,
@@ -27,6 +44,7 @@ fn create_test_server(
         spa_mode,
         config_prefix: "TEST_".to_string(),
         log_requests: false,
+        engine,
     };
 
     tokio::spawn(async move {
@@ -541,5 +559,162 @@ async fn test_cache_control_values() {
     assert_eq!(
         resp.headers().get("cache-control").unwrap(),
         "public, max-age=3600"
+    );
+}
+
+// ── Raw engine ───────────────────────────────────────────────────────────────
+// The raw engine (hand-rolled HTTP/1.1, no hyper) must match the production
+// engine's observable behaviour. These mirror the core hyper-path assertions.
+
+use nano_web::server::Engine;
+
+#[tokio::test]
+async fn test_raw_serves_body_and_headers() {
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join("index.html"), "<h1>raw</h1>").unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    let resp = reqwest::get(format!("http://localhost:{port}/"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "text/html");
+    assert_eq!(
+        resp.headers().get("x-content-type-options").unwrap(),
+        "nosniff"
+    );
+    assert!(resp.headers().get("etag").is_some());
+    assert_eq!(resp.headers().get("content-length").unwrap(), "12");
+    assert_eq!(resp.text().await.unwrap(), "<h1>raw</h1>");
+}
+
+#[tokio::test]
+async fn test_raw_brotli_encoding() {
+    let temp_dir = TempDir::new().unwrap();
+    // >1KB compressible so compression kicks in
+    fs::write(temp_dir.path().join("app.js"), "// comment\n".repeat(200)).unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::builder()
+        .no_gzip()
+        .no_brotli()
+        .build()
+        .unwrap();
+    let resp = client
+        .get(format!("http://localhost:{port}/app.js"))
+        .header("accept-encoding", "br")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-encoding").unwrap(), "br");
+    assert_eq!(resp.headers().get("vary").unwrap(), "Accept-Encoding");
+}
+
+#[tokio::test]
+async fn test_raw_404_and_405() {
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join("index.html"), "<h1>raw</h1>").unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    let resp = reqwest::get(format!("http://localhost:{port}/missing"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn test_raw_head_and_304() {
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join("index.html"), "<h1>raw</h1>").unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    // HEAD: headers present, body empty
+    let resp = reqwest::Client::new()
+        .head(format!("http://localhost:{port}/"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-length").unwrap(), "12");
+    assert!(resp.bytes().await.unwrap().is_empty());
+
+    // Fetch etag, then conditional GET → 304
+    let resp = reqwest::get(format!("http://localhost:{port}/"))
+        .await
+        .unwrap();
+    let etag = resp
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let resp = reqwest::Client::new()
+        .get(format!("http://localhost:{port}/"))
+        .header("if-none-match", etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn test_raw_health() {
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join("index.html"), "<h1>raw</h1>").unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    let resp = reqwest::get(format!("http://localhost:{port}/_health"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp.text().await.unwrap().contains("ok"));
+}
+
+#[tokio::test]
+async fn test_raw_path_traversal_blocked() {
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join("index.html"), "<h1>raw</h1>").unwrap();
+
+    let port = get_free_port();
+    let _server = create_test_server_engine(temp_dir.path(), port, false, false, Engine::Raw);
+    sleep(Duration::from_millis(100)).await;
+
+    // reqwest normalizes ../ client-side, so hit the socket raw.
+    let mut s = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+    s.write_all(b"GET /../../etc/passwd HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    let mut resp = String::new();
+    s.read_to_string(&mut resp).await.unwrap();
+    assert!(
+        resp.starts_with("HTTP/1.1 400"),
+        "expected 400, got: {}",
+        &resp[..resp.len().min(40)]
     );
 }


### PR DESCRIPTION
## ⚠️ Negative result — do NOT merge as a perf win

This branch adds an experimental `--engine uring` (Linux, monoio/io_uring, thread-per-core) plus the shared `engine::route` core and the `raw` tokio engine. **Rigorous benchmarking shows io_uring does NOT beat the production hyper engine**, so this stays an experiment.

### What happened

An early co-located `oha -c50` run showed io_uring +24–112% over hyper. That was an **artifact of one low-concurrency, CPU-contended config**. A proper sweep on oldboy (2014 i7-4870HQ, 4C/8T) tells the real story:

| config | hyper | uring | winner |
| --- | --- | --- | --- |
| `-c200` co-located | 101,338 rps | 69,321 rps | **hyper +46%** |
| `-c1000` co-located | 55,117 rps | 55,612 rps | tie |
| `-c50` pinned (6 cores) | 2× | — | **hyper 2×** |

At `-c50` the dynamics are a latency race (8 conns/shard, nothing saturated); monoio's io_uring ring adds per-request latency that only batches out under load. At saturation, hyper's tuned writer + tokio work-stealing beat naive `SO_REUSEPORT` static sharding.

### Why hyper wins
Years of optimization; work-stealing load-balances connections better than static sharding; the monoio engine here is deliberately naive (single read, no pipelining, closes on partial parse). A sophisticated io_uring engine (registered buffers, multishot recv, SQPOLL) *might* compete — unproven, large effort.

### What's worth keeping (separately)
- The `engine::route`/`Reply` refactor (clean transport-agnostic core).
- The benchmark harness in `bench/` (already on main) — it caught this false win.

The Arc-lookup production win was split out and merged separately (#20). This branch is kept for the record as a documented negative result.